### PR TITLE
Bugfix in training code: Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,12 +38,12 @@ tornado  # Used in nuboard.py
 tqdm  # Used widely
 ujson  # Used in serialiation_callback.py
 
-# pytorch-lightning==2.5.1
+pytorch-lightning==2.4.0
 # tensorboard==2.19.0
 # # protobuf==4.25.3
 
 # # notebook
-# timm==1.0.15
+timm==1.0.15
 
 # # mmcv_full==1.7.2
 # # mmdet==2.28.2


### PR DESCRIPTION
`pytorch-lightning` and `timm` are necessary for training on NAVSIM.