### PR TITLE
Comment out extend_observation_for_ttc parameter

### DIFF
--- a/navsim/planning/metric_caching/train_cache_processor_synt.py
+++ b/navsim/planning/metric_caching/train_cache_processor_synt.py
@@ -212,7 +212,7 @@ class MetricCacheProcessor:
             self._proposal_sampling,
             self._map_radius,
             observation_sample_res=1,
-            extend_observation_for_ttc=False,
+            # extend_observation_for_ttc=False,
         )
         pdm_observation.update_detections_tracks(interpolated_detection_tracks)
         return pdm_observation


### PR DESCRIPTION
Comment out the extend_observation_for_ttc parameter in the function call.